### PR TITLE
Make call to uname portable.

### DIFF
--- a/thermald/Makefile
+++ b/thermald/Makefile
@@ -11,7 +11,7 @@ EXTRA_CFLAGS := $(CFLAGS)
 CFLAGS  := -Wall -g $(EXTRA_CFLAGS)
 LDLIBS  := $(LDFLAGS) -lm
 
-ARCH    ?= $(shell uname -p)
+ARCH    ?= $(shell uname -m)
 ifneq ($(ARCH), armv7l)
 	CC := $(CROSS_COMPILE)gcc
 endif


### PR DESCRIPTION
Minor change to expand compability in Makefile. Some distributions do not exhibit expected behavior with the -p flag, but work fine with -m:

e.g. Arch Linux ARM:

```
% uname -p
unknown

% uname -m
armv7l
```

From uname's man page:

```
       -m, --machine
              print the machine hardware name

       -p, --processor
              print the processor type (non-portable)
```
